### PR TITLE
Fixed. `NameError: uninitialized constant ActiveSupport::XmlMini::IsolatedExecutionState` with activesupport v7.0.0

### DIFF
--- a/lib/rspec/time_stop.rb
+++ b/lib/rspec/time_stop.rb
@@ -1,5 +1,12 @@
 require "rspec/time_stop/version"
 require "rspec"
+
+begin
+  # workaround for activesupport 7.0.0
+  # c.f. https://github.com/rails/rails/issues/43851
+  require "active_support/isolated_execution_state"
+rescue LoadError
+end
 require "active_support/testing/time_helpers"
 
 RSpec.shared_context "rspec-time_stop", shared_context: :metadata do


### PR DESCRIPTION
Close #18